### PR TITLE
fixed a build error on Linux platform

### DIFF
--- a/Plug-in/Source/ModuloSameSignAsDivisor.cpp
+++ b/Plug-in/Source/ModuloSameSignAsDivisor.cpp
@@ -25,7 +25,7 @@
 
 float ModuloSameSignAsDivisor::mod(const float x, const float y)
 {
-    const auto a = std::fmodf(x, y);
+    const auto a = std::fmod(x, y);
     const auto b = a + y;
-    return std::fmodf(b, y);
+    return std::fmod(b, y);
 }


### PR DESCRIPTION
Hi, the patch allows to compile on Linux platforms, where GCC standard library does not define `fmodf` inside the `std` namespace.